### PR TITLE
Update main and sealed example error message ui

### DIFF
--- a/lib/features/sealed_example/sealed_status.dart
+++ b/lib/features/sealed_example/sealed_status.dart
@@ -24,6 +24,7 @@ class SealedStatusExPageState extends State<SealedStatusExPage> {
   @override
   Widget build(BuildContext context) {
     final status = this.status;
+    final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
 
     return Scaffold(
       appBar: AppBar(
@@ -50,7 +51,25 @@ class SealedStatusExPageState extends State<SealedStatusExPage> {
                       return Text('${data.key}: ${data.value}', textAlign: TextAlign.start,);
                     },)
                   else if(status case ErrorState())
-                      Text(status.content, textAlign: TextAlign.center,),
+                      Padding(
+                        padding: EdgeInsets.only(top: 8*devicePixelRatio),
+                        child: Column(
+                          children: [
+                            Icon(
+                              Icons.error_outline,
+                              size: 24*devicePixelRatio,
+                            ),
+                            const SizedBox(height: 15,),
+                            Text(
+                              status.content,
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                fontSize: 6*devicePixelRatio,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                 ],
               ),
             )),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,13 +42,15 @@ class _MyHomePageState extends State<MyHomePage> {
         padding: const EdgeInsets.all(15),
         child: Wrap(
           spacing: 15,
-          runSpacing: double.maxFinite,
           children: [
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(MaterialPageRoute(builder: (context) => const SealedStatusExPage(),),);
-              },
-              child: const Text('Sealed class example'),
+            SizedBox(
+              width: double.maxFinite,
+              child: FilledButton(
+                onPressed: () {
+                  Navigator.of(context).push(MaterialPageRoute(builder: (context) => const SealedStatusExPage(),),);
+                },
+                child: const Text('Sealed class example'),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
- Fixed main page button take full width
- Sealed class status example page: update error message with icon and calculate size of contend with device pixel ratio